### PR TITLE
Added an explicit System.Security assembly loading

### DIFF
--- a/VSCELicense.psm1
+++ b/VSCELicense.psm1
@@ -7,6 +7,7 @@ New-Variable -Name VSCELicenseMap -Value @{
 
 #endregion
 
+Add-Type -assembly System.Security
 
 <#
 .Synopsis


### PR DESCRIPTION
This fixes "Unable to find type" [System.Security.Cryptography.ProtectedData] error.