### PR TITLE
Fix VS2022 preview key

### DIFF
--- a/VSCELicense.psm1
+++ b/VSCELicense.psm1
@@ -5,7 +5,7 @@ New-Variable -Name VSCELicenseMap -Value @{
     '2017' = 'Licenses\5C505A59-E312-4B89-9508-E162F8150517\08878'
     '2019' = 'Licenses\41717607-F34E-432C-A138-A3CFD7E25CDA\09278'
     # TODO: Preview version, replace with Release
-    '2022' = 'Licenses\10D17DBA-761D-4CD8-A627-984E75A58700\09378'
+    '2022' = 'Licenses\10D17DBA-761D-4CD8-A627-984E75A58700\09478'
 } -Option Constant
 
 #endregion

--- a/VSCELicense.psm1
+++ b/VSCELicense.psm1
@@ -5,7 +5,7 @@ New-Variable -Name VSCELicenseMap -Value @{
     '2017' = 'Licenses\5C505A59-E312-4B89-9508-E162F8150517\08878'
     '2019' = 'Licenses\41717607-F34E-432C-A138-A3CFD7E25CDA\09278'
     # TODO: Preview version, replace with Release
-    '2022' = 'Licenses\10D17DBA-761D-4CD8-A627-984E75A58700\09478'
+    '2022' = 'Licenses\10D17DBA-761D-4CD8-A627-984E75A58700\09460'
 } -Option Constant
 
 #endregion


### PR DESCRIPTION
I committed correct key on my fork(29e7827ee9dcc298cb9327d519ee6162e19c8d66) and invalid one on previous PR https://github.com/beatcracker/VSCELicense/pull/15 , my apologies😢
![image](https://user-images.githubusercontent.com/71011169/129760079-bde00073-6022-41ac-8bec-ea73453ec17a.png)
