### PR TITLE
Added 2013 uuid.

### DIFF
--- a/VSCELicense.psm1
+++ b/VSCELicense.psm1
@@ -1,6 +1,7 @@
 #region Constants
 
 New-Variable -Name VSCELicenseMap -Value @{
+    '2013' = 'Licenses\E79B3F9C-6543-4897-BBA5-5BFB0A02BB5C\06177'
     '2015' = 'Licenses\4D8CFBCB-2F6A-4AD2-BABF-10E28F6F2C8F\07078'
     '2017' = 'Licenses\5C505A59-E312-4B89-9508-E162F8150517\08878'
     '2019' = 'Licenses\41717607-F34E-432C-A138-A3CFD7E25CDA\09278'
@@ -132,7 +133,7 @@ Function Open-HKCRSubKey {
 
 .Parameter Version
     String array. One ore more of the supported Visual Studio Community Edition versions.
-    Default: '2015', '2017', '2019'
+    Default: '2013', '2015', '2017', '2019'
 
 .Example
     Get-VSCELicenseExpirationDate -Version 2017
@@ -147,8 +148,8 @@ Function Open-HKCRSubKey {
 function Get-VSCELicenseExpirationDate {
     [CmdletBinding()]
     Param (
-        [ValidateSet('2015', '2017', '2019')]
-        [string[]]$Version = @('2015', '2017', '2019')
+        [ValidateSet('2013', '2015', '2017', '2019')]
+        [string[]]$Version = @('2013', '2015', '2017', '2019')
     )
 
     End {
@@ -190,7 +191,7 @@ function Get-VSCELicenseExpirationDate {
 
 .Parameter Version
     String array. One ore more of the supported Visual Studio Community Edition versions.
-    Default: '2015', '2017', '2019'
+    Default: '2013', '2015', '2017', '2019'
 
 .Parameter AddDays
     Int. Number of days to add. 31 is max allowed and default.
@@ -219,8 +220,8 @@ function Get-VSCELicenseExpirationDate {
 function Set-VSCELicenseExpirationDate {
     [CmdletBinding()]
     Param (
-        [ValidateSet('2015', '2017', '2019')]
-        [string[]]$Version = @('2015', '2017', '2019'),
+        [ValidateSet('2013', '2015', '2017', '2019')]
+        [string[]]$Version = @('2013', '2015', '2017', '2019'),
 
         [ValidateRange(0, 31)]
         [int]$AddDays = 31


### PR DESCRIPTION
Added the necessary UUID and information to get these commands to work with my copy of Visual Studio Community 2013.

I tested it using `-AddDays 0` and confirmed the license expired dialog popped up. Then without that, defaulting to adding 31 days, VSC2013 worked as expected.